### PR TITLE
Add Support for Gradient Release

### DIFF
--- a/docs/gradient_release.md
+++ b/docs/gradient_release.md
@@ -36,8 +36,8 @@ from optimi import AdamW
 # create or cast model in low precision (bfloat16)
 model = nn.Linear(20, 1, dtype=torch.bfloat16)
 
-# instantiate AdamW with `gradient_release=True` and call
-# `prepare_for_gradient_release` on model and optimizer
+# initialize any optimi optimizer with `gradient_release=True`
+# and call `prepare_for_gradient_release` on model and optimizer
 opt = AdamW(model.parameters(), lr=1e-3, gradient_release=True)
 prepare_for_gradient_release(model, opt)
 

--- a/docs/gradient_release.md
+++ b/docs/gradient_release.md
@@ -1,0 +1,55 @@
+---
+title: "Gradient Release: Fused Backward and Optimizer Step"
+---
+
+# Gradient Release: Fused Backward and Optimizer Step
+
+Gradient release reduces training memory by limiting gradients to one layer at any given time. Unlike [PyTorch’s implementation](https://pytorch.org/tutorials/intermediate/optimizer_step_in_backward_tutorial.html), optimi’s gradient release is fully compatible with existing learning rate and optimizer schedulers and training frameworks.
+
+During the backward pass, each model layer calculates its gradients, performs the optimizer step, and clears the gradients before proceeding to the backward pass for the next layer. This fused backward and optimizer step can reduce non-activation memory usage by ~25 percent for an Adam optimizer.
+
+Gradient release can be combined with other techniques such as [Kahan summation](kahan_summation.md) or activation checkpointing for further memory savings.
+
+??? warning "Important: Gradient Release Requires PyTorch 2.1+"
+
+    Gradient release requires PyTorch 2.1 or newer.
+
+Gradient release was proposed by Pudipeddi et al in [*Training Large Neural Networks with Constant Memory using a New Execution Algorithm*](https://arxiv.org/abs/2002.05645) and was enabled by PyTorch’s [`register_post_accumulate_grad_hook`](https://pytorch.org/docs/stable/generated/torch.Tensor.register_post_accumulate_grad_hook.html).
+
+## Limitations and Workarounds
+
+Since gradient release immediately frees the gradient during the backward pass, features which rely on persistent gradients like gradient clipping or gradient accumulation won’t work.
+
+The recommended workaround for gradient clipping is to use [StableAdamW](optimizers/stableadamw.md) instead of Adam or AdamW, as StableAdamW removes the need for gradient clipping by porting Adafactor’s update clipping into AdamW.
+
+One potential workaround for gradient accumulation is to increase the optimizer’s momentum or $\beta_1$ to approximate accumulating gradients across multiple batches.
+
+## Example
+
+Using optimi’s gradient release requires two steps: initializing the optimizer with `gradient_release=True` and calling `prepare_for_gradient_release` on both the model and optimizer.
+
+```python
+import torch
+from torch import nn
+from optimi import AdamW
+
+# create or cast model in low precision (bfloat16)
+model = nn.Linear(20, 1, dtype=torch.bfloat16)
+
+# instantiate AdamW with `gradient_release=True` and call
+# `prepare_for_gradient_release` on model and optimizer
+opt = AdamW(model.parameters(), lr=1e-3, gradient_release=True)
+prepare_for_gradient_release(model, opt)
+
+# calling backward on the model will peform the optimzier step
+loss = model(torch.randn(20, dtype=torch.bfloat16))
+loss.backward()
+
+# optimizer step and sero_grad is no longer needed, and
+# will no-op if called by an existing training framework
+opt.step()
+opt.zero_grad()
+
+# optionally remove gradient release hooks when done training
+remove_gradient_release(model)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,12 @@ optimi optimizers can match the performance of mixed precision when [training in
 
 Training in BFloat16 with Kahan summation can reduce non-activation training memory usage by [37.5 to 45.5 percent](kahan_summation.md/#memory-savings) when using an Adam optimizer. BFloat16 training increases single GPU [training speed by ~10 percent](kahan_summation.md/#training-speedup) at the same batch size.
 
+## Gradient Release: Fused Backward and Optimizer Step
+
+optimi optimizers can perform the [optimization step layer-by-layer during the backward pass](gradient_release.md), immediately freeing gradient memory.
+
+Unlike the current PyTorch implementation, optimi’s gradient release optimizers are a drop-in replacement for standard optimizers and seamlessly work with exisiting hyperparmeter schedulers.
+
 ## Fully Decoupled Weight Decay
 
 In addition to supporting PyTorch-style decoupled weight decay, optimi optimizers also support [fully decoupled weight decay](fully_decoupled_weight_decay.md).
@@ -45,7 +51,7 @@ from optimi import AdamW
 # create or cast model in low precision (bfloat16)
 model = nn.Linear(20, 1, dtype=torch.bfloat16)
 
-# instantiate AdamW with parameters and fully decoupled weight decay
+# initialize AdamW with parameters and fully decoupled weight decay
 # Kahan summation is automatically enabled since model & inputs are bfloat16
 opt = AdamW(model.parameters(), lr=1e-3, weight_decay=1e-5, decouple_lr=True)
 
@@ -64,8 +70,32 @@ To use with PyTorch-style weight decay with float32 or mixed precision:
 # create model
 model = nn.Linear(20, 1)
 
-# instantiate AdamW with parameters
+# initialize AdamW with parameters
 opt = AdamW(model.parameters(), lr=1e-3, weight_decay=1e-2)
+```
+
+To use with gradient release:
+
+```python
+# create model
+model = nn.Linear(20, 1)
+
+# initialize AdamW with `gradient_release=True` and call
+# `prepare_for_gradient_release` on model and optimizer
+opt = AdamW(model.parameters(), lr=1e-3, gradient_release=True)
+prepare_for_gradient_release(model, opt)
+
+# calling backward on the model will peform the optimzier step
+loss = model(torch.randn(20, dtype=torch.bfloat16))
+loss.backward()
+
+# optimizer step and sero_grad is no longer needed, and
+# will no-op if called by an existing training framework
+opt.step()
+opt.zero_grad()
+
+# optionally remove gradient release hooks when done training
+remove_gradient_release(model)
 ```
 
 ## Differences from PyTorch

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,9 @@ extra_css:
 
 nav:
   - Low Precision Training: kahan_summation.md
-  - Fully Decoupled Weight Decay: fully_decoupled_weight_decay.md
+  - Gradient Release: gradient_release.md
   - ForEach Optimizers: foreach.md
+  - Fully Decoupled Weight Decay: fully_decoupled_weight_decay.md
   - Which Optimizer?: which_optimizer.md
   - Optimizers:
     - Adam: optimizers/adam.md

--- a/optimi/__init__.py
+++ b/optimi/__init__.py
@@ -5,6 +5,7 @@ __version__ = version("torch-optimi")
 from .adam import Adam, adam
 from .adamw import AdamW, adamw
 from .adan import Adan, adan
+from .gradientrelease import prepare_for_gradient_release, remove_gradient_release
 from .lion import Lion, lion
 from .radam import RAdam, radam
 from .ranger import Ranger, ranger

--- a/optimi/adam.py
+++ b/optimi/adam.py
@@ -13,19 +13,19 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Iterable
-from warnings import warn
 
 import torch
 from torch import Tensor
-from torch.optim.optimizer import Optimizer, _default_to_fused_or_foreach
+from torch.optim.optimizer import _default_to_fused_or_foreach
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
-from optimi.utils import MIN_TORCH_2_1, debias_beta
+from optimi.optimizer import OptimiOptimizer
+from optimi.utils import debias_beta
 
 __all__ = ["Adam", "adam"]
 
 
-class Adam(Optimizer):
+class Adam(OptimiOptimizer):
     """Adam optimizer. Optionally with decoupled weight decay (AdamW).
 
     Args:
@@ -44,6 +44,9 @@ class Adam(Optimizer):
             parameters (default: None)
         foreach: Enables the foreach implementation. If unspecified, tries to use foreach over
             for-loop implementation since it is significantly faster (default: None)
+        gradient_release: Fuses optimizer step and zero_grad as part of the parameter's backward
+            pass. Requires model hooks created with `register_gradient_release`. Incompatible with
+            closure (default: False)
     """
 
     def __init__(
@@ -58,32 +61,12 @@ class Adam(Optimizer):
         max_lr: float | None = None,
         kahan_sum: bool | None = None,
         foreach: bool | None = None,
+        gradient_release: bool = False,
     ):
-        if not 0.0 <= lr:
-            raise ValueError(f"Invalid learning rate: {lr=}")
         if not 0.0 <= betas[0] < 1.0:
             raise ValueError(f"Invalid beta1 parameter: {betas[0]=}")
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError(f"Invalid beta2 parameter: {betas[1]=}")
-        if not 0.0 <= weight_decay:
-            raise ValueError(f"Invalid weight decay: {weight_decay=}")
-        if not 0.0 <= eps:
-            raise ValueError(f"Invalid epsilon: {eps=}")
-        if decouple_lr and max_lr is None:
-            max_lr = lr
-        if max_lr is not None and not 0.0 <= max_lr:
-            raise ValueError(f"Invalid maximum learning rate: {max_lr=}")
-        if decouple_lr and weight_decay >= 1e-3:
-            warn(
-                f"You are using {weight_decay=} which is potentially high for {decouple_lr=}. Unlike decoupled weight "
-                f"decay, fully decoupled weight decay does not reduce weight decay by the learning rate.",
-                category=UserWarning,
-            )
-        if not MIN_TORCH_2_1:
-            if foreach:
-                raise ValueError(f"{foreach=} requires PyTorch 2.1 or later. Set foreach=False or upgrade PyTorch.")
-            else:
-                foreach = False
 
         defaults = dict(
             lr=lr,
@@ -96,9 +79,24 @@ class Adam(Optimizer):
             max_lr=max_lr,
             kahan_sum=kahan_sum,
             foreach=foreach,
+            gradient_release=gradient_release,
             setup=False,
         )
         super().__init__(params, defaults)
+
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor, gradient_release: bool = False):
+        if len(state) <= 1:
+            state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+            state["exp_avg_sq"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+
+            if (group["kahan_sum"] or group["kahan_sum"] is None) and param.dtype in [torch.float16, torch.bfloat16]:
+                state["kahan_comp"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+                group["kahan_sum"] = True
+            else:
+                state["kahan_comp"] = None
+
+            if gradient_release:
+                state["step"] = torch.tensor(0, dtype=torch.int32)
 
     def _init_group(
         self,
@@ -117,16 +115,7 @@ class Adam(Optimizer):
             grads.append(p.grad)
             state = self.state[p]
 
-            # State initialization
-            if len(state) == 0:
-                state["exp_avg"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                state["exp_avg_sq"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-
-                if (group["kahan_sum"] or group["kahan_sum"] is None) and p.dtype in [torch.float16, torch.bfloat16]:
-                    state["kahan_comp"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                    group["kahan_sum"] = True
-                else:
-                    state["kahan_comp"] = None
+            self._init_state(group, state, p)
 
             exp_avgs.append(state["exp_avg"])
             exp_avg_sqs.append(state["exp_avg_sq"])
@@ -140,38 +129,68 @@ class Adam(Optimizer):
                 _, group["foreach"] = _default_to_fused_or_foreach(params, False, False)
 
     @torch.no_grad()
-    def step(self, closure: Callable | None = None):
-        """Performs a single optimization step.
+    def step(self, closure: Callable | None = None, param: Tensor | None = None):
+        """Performs a single optimization step on the whole model or individual parameter.
 
         Args:
-            closure: A closure which reevaluates the model and returns the loss
+            closure: A closure which reevaluates the model and returns the loss. Incompatible with
+                performing an optimization step on a single `param`.
+            param: An individual parameter to perform a fused optimization step during the backward
+                pass. Requires optimizer to be initialized with `gradient_release=True` and model
+                hooks created with `register_gradient_release`. Incompatible with `closure`.
         """
         loss = None
-        if closure is not None:
+        if closure is not None and param is None:
             with torch.enable_grad():
                 loss = closure()
 
-        for group in self.param_groups:
-            params, grads, exp_avgs, exp_avg_sqs, kahan_comps = [], [], [], [], []
-            self._init_group(group, params, grads, exp_avgs, exp_avg_sqs, kahan_comps)
+        if param is None:
+            for group in self.param_groups:
+                params, grads, exp_avgs, exp_avg_sqs, kahan_comps = [], [], [], [], []
+                self._init_group(group, params, grads, exp_avgs, exp_avg_sqs, kahan_comps)
+
+                adam(
+                    params=params,
+                    grads=grads,
+                    exp_avgs=exp_avgs,
+                    exp_avg_sqs=exp_avg_sqs,
+                    kahan_comps=kahan_comps,
+                    lr=group["lr"],
+                    beta1=group["beta1"],
+                    beta2=group["beta2"],
+                    weight_decay=group["weight_decay"],
+                    eps=group["eps"],
+                    step=group["step"],
+                    decouple_wd=group["decouple_wd"],
+                    decouple_lr=group["decouple_lr"],
+                    max_lr=group["max_lr"],
+                    kahan_sum=group["kahan_sum"],
+                    foreach=group["foreach"],
+                    gradient_release=False,
+                )
+        else:
+            state = self.state[param]
+            group = state["group"]
+            self._init_state(group, state, param, True)
 
             adam(
-                params=params,
-                grads=grads,
-                exp_avgs=exp_avgs,
-                exp_avg_sqs=exp_avg_sqs,
-                kahan_comps=kahan_comps,
+                params=param,
+                grads=param.grad,
+                exp_avgs=state["exp_avg"],
+                exp_avg_sqs=state["exp_avg_sq"],
+                kahan_comps=state["kahan_comp"],
                 lr=group["lr"],
                 beta1=group["beta1"],
                 beta2=group["beta2"],
                 weight_decay=group["weight_decay"],
                 eps=group["eps"],
-                step=group["step"],
+                step=state["step"],
                 decouple_wd=group["decouple_wd"],
                 decouple_lr=group["decouple_lr"],
                 max_lr=group["max_lr"],
                 kahan_sum=group["kahan_sum"],
                 foreach=group["foreach"],
+                gradient_release=True,
             )
 
         return loss
@@ -195,6 +214,7 @@ def adam(
     max_lr: float | None = None,
     kahan_sum: bool = False,
     foreach: bool = False,
+    gradient_release: bool = False,
 ):
     """Functional API to apply an Adam or AdamW optimization step.
 
@@ -217,6 +237,7 @@ def adam(
         max_lr: Maximum scheduled learning rate for `decouple_lr`
         kahan_sum: Enables Kahan summation for low precision parameters
         foreach: Enables the faster foreach implementation
+        gradient_release: Fuses optimizer step as part of the parameter's backward pass
     """
     # calculate debiased beta hat & complement terms
     step.add_(1)
@@ -235,15 +256,17 @@ def adam(
 
     if foreach:
         func = _foreach_adam
+    elif gradient_release:
+        func = _single_param_adam
     else:
         func = _single_adam
 
     func(
-        params=params,
-        grads=grads,
-        exp_avgs=exp_avgs,
-        exp_avg_sqs=exp_avg_sqs,
-        kahan_comps=kahan_comps,
+        params,
+        grads,
+        exp_avgs,
+        exp_avg_sqs,
+        kahan_comps,
         lr=lr,
         beta1_comp=beta1_comp,
         beta2_hat=beta2_hat,
@@ -275,30 +298,61 @@ def _single_adam(
         exp_avg_sq = exp_avg_sqs[i]
         kahan_comp = kahan_comps[i]
 
-        # decoupled weight decay, fully decoupled weight decay, or L2 weight decay
-        if weight_decay != 0:
-            if decouple_wd:
-                param.mul_(weight_decay)
-            else:
-                grad.add_(param, alpha=weight_decay)
+        _single_param_adam(
+            param=param,
+            grad=grad,
+            exp_avg=exp_avg,
+            exp_avg_sq=exp_avg_sq,
+            kahan_comp=kahan_comp,
+            lr=lr,
+            beta1_comp=beta1_comp,
+            beta2_hat=beta2_hat,
+            weight_decay=weight_decay,
+            eps=eps,
+            decouple_wd=decouple_wd,
+            kahan_sum=kahan_sum,
+        )
 
-        # update gradient moving averages with debiased betas
-        exp_avg.lerp_(grad, weight=beta1_comp)
-        exp_avg_sq.mul_(beta2_hat).addcmul_(grad, grad, value=1 - beta2_hat)
 
-        if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
-            # Adam step
-            kahan_comp.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
-
-            # update weights with kahan compensation using grad as temp buffer
-            grad.copy_(param.detach())
-            param.add_(kahan_comp)
-
-            # save error back to kahan compensation for next iteration
-            kahan_comp.add_(grad.sub_(param))
+def _single_param_adam(
+    param: Tensor,
+    grad: Tensor,
+    exp_avg: Tensor,
+    exp_avg_sq: Tensor,
+    kahan_comp: Tensor | None,
+    *,
+    lr: float,
+    beta1_comp: float,
+    beta2_hat: float,
+    weight_decay: float,
+    eps: float,
+    decouple_wd: bool,
+    kahan_sum: bool = False,
+):
+    # decoupled weight decay, fully decoupled weight decay, or L2 weight decay
+    if weight_decay != 0:
+        if decouple_wd:
+            param.mul_(weight_decay)
         else:
-            # Adam step
-            param.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
+            grad.add_(param, alpha=weight_decay)
+
+    # update gradient moving averages with debiased betas
+    exp_avg.lerp_(grad, weight=beta1_comp)
+    exp_avg_sq.mul_(beta2_hat).addcmul_(grad, grad, value=1 - beta2_hat)
+
+    if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
+        # Adam step
+        kahan_comp.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
+
+        # update weights with kahan compensation using grad as temp buffer
+        grad.copy_(param.detach())
+        param.add_(kahan_comp)
+
+        # save error back to kahan compensation for next iteration
+        kahan_comp.add_(grad.sub_(param))
+    else:
+        # Adam step
+        param.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
 
 
 def _foreach_adam(

--- a/optimi/adam.py
+++ b/optimi/adam.py
@@ -86,7 +86,7 @@ class Adam(OptimiOptimizer):
         )
         super().__init__(params, defaults)
 
-    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor, gradient_release: bool = False):
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor):
         if len(state) <= 1:
             state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
             state["exp_avg_sq"] = torch.zeros_like(param, memory_format=torch.preserve_format)
@@ -97,7 +97,7 @@ class Adam(OptimiOptimizer):
             else:
                 state["kahan_comp"] = None
 
-            if gradient_release:
+            if group["gradient_release"]:
                 state["step"] = torch.tensor(0, dtype=torch.int32)
 
     def _init_group(
@@ -173,7 +173,7 @@ class Adam(OptimiOptimizer):
         else:
             state = self.state[param]
             group = state["group"]
-            self._init_state(group, state, param, True)
+            self._init_state(group, state, param)
 
             adam(
                 params=param,

--- a/optimi/adam.py
+++ b/optimi/adam.py
@@ -67,6 +67,8 @@ class Adam(OptimiOptimizer):
             raise ValueError(f"Invalid beta1 parameter: {betas[0]=}")
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError(f"Invalid beta2 parameter: {betas[1]=}")
+        if not 0.0 <= eps:
+            raise ValueError(f"Invalid epsilon: {eps=}")
 
         defaults = dict(
             lr=lr,
@@ -189,7 +191,7 @@ class Adam(OptimiOptimizer):
                 decouple_lr=group["decouple_lr"],
                 max_lr=group["max_lr"],
                 kahan_sum=group["kahan_sum"],
-                foreach=group["foreach"],
+                foreach=False,
                 gradient_release=True,
             )
 

--- a/optimi/adamw.py
+++ b/optimi/adamw.py
@@ -40,6 +40,9 @@ class AdamW(Adam):
             parameters (default: None)
         foreach: Enables the foreach implementation. If unspecified, tries to use foreach over
             for-loop implementation since it is significantly faster (default: None)
+        gradient_release: Fuses optimizer step and zero_grad as part of the parameter's backward
+            pass. Requires model hooks created with `register_gradient_release`. Incompatible with
+            closure (default: False)
     """
 
     def __init__(
@@ -53,6 +56,7 @@ class AdamW(Adam):
         max_lr: float | None = None,
         kahan_sum: bool | None = None,
         foreach: bool | None = None,
+        gradient_release: bool = False,
     ):
         super().__init__(
             params=params,
@@ -65,6 +69,7 @@ class AdamW(Adam):
             max_lr=max_lr,
             kahan_sum=kahan_sum,
             foreach=foreach,
+            gradient_release=gradient_release,
         )
 
 
@@ -85,6 +90,7 @@ def adamw(
     max_lr: float | None = None,
     kahan_sum: bool = False,
     foreach: bool = False,
+    gradient_release: bool = False,
 ):
     """Functional API to apply an AdamW optimization step.
 
@@ -106,6 +112,7 @@ def adamw(
         max_lr: Maximum scheduled learning rate for `decouple_lr`
         kahan_sum: Enables Kahan summation for low precision `params`
         foreach: Enables the faster foreach implementation
+        gradient_release: Fuses optimizer step as part of the parameter's backward pass
     """
     adam(
         params=params,
@@ -124,4 +131,5 @@ def adamw(
         max_lr=max_lr,
         kahan_sum=kahan_sum,
         foreach=foreach,
+        gradient_release=gradient_release,
     )

--- a/optimi/gradientrelease.py
+++ b/optimi/gradientrelease.py
@@ -22,8 +22,8 @@ def prepare_for_gradient_release(model: Module, optimizer: OptimiOptimizer, igno
             `requires_grad=True`.
         optimizer: Optimizer providing the fused optimizer step during the backward pass. Requires
             optimizer to be initialized with `gradient_release=True`
-        ignore_existing_hooks: If True, will not register post_accumulate_grad_hooks if the model
-            (default: False)
+        ignore_existing_hooks: If True, ignores existing post_accumulate_grad_hooks on parameters
+            and registers gradient release hooks (default: False)
     """
     if not isinstance(optimizer, OptimiOptimizer):
         raise TypeError("`optimizer` must be an instance of `OptimiOptimizer`")

--- a/optimi/gradientrelease.py
+++ b/optimi/gradientrelease.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from functools import partial
+from warnings import warn
+
+from torch import Tensor
+from torch.nn import Module
+
+from optimi.optimizer import OptimiOptimizer
+
+
+def _gradient_release_hook(param: Tensor, optimizer: OptimiOptimizer):
+    optimizer.step(param=param)
+    optimizer.zero_grad(param=param)
+
+
+def prepare_for_gradient_release(model: Module, optimizer: OptimiOptimizer, ignore_existing_hooks: bool = False):
+    """Register post_accumulate_grad_hooks on parameters for the gradient release optimization step.
+
+    Args:
+        model: Model to register post_accumulate_grad_hooks. Only registers on parameters with
+            `requires_grad=True`.
+        optimizer: Optimizer providing the fused optimizer step during the backward pass. Requires
+            optimizer to be initialized with `gradient_release=True`
+        ignore_existing_hooks: If True, will not register post_accumulate_grad_hooks if the model
+            (default: False)
+    """
+    if not isinstance(optimizer, OptimiOptimizer):
+        raise TypeError("`optimizer` must be an instance of `OptimiOptimizer`")
+    if not optimizer.defaults["gradient_release"]:
+        raise ValueError("`optimizer` must be initialized with `gradient_release=True`")
+
+    hooks = []
+    for p in model.parameters():
+        if p.requires_grad:
+            if (p._post_accumulate_grad_hooks is not None) and len(p._post_accumulate_grad_hooks) > 0 and (not ignore_existing_hooks):
+                for hook in hooks:
+                    if hasattr(hook, "remove"):
+                        hook.remove()
+                raise ValueError(
+                    "Model already has post_accumulate_grad_hooks. If this is expected, rerun with `ignore_existing_hooks=True`."
+                )
+            hooks.append(p.register_post_accumulate_grad_hook(partial(_gradient_release_hook, optimizer=optimizer)))
+    model._gradient_release_hooks = hooks
+
+
+def remove_gradient_release(model: Module):
+    """Removes post_accumulate_grad_hooks created by `prepare_for_gradient_release`.
+
+    Args:
+        model: Model to remove gradient release post_accumulate_grad_hooks from.
+    """
+    if not hasattr(model, "_gradient_release_hooks"):
+        warn("`model` does not have any gradient release post_accumulate_grad_hooks to remove.")
+        return
+
+    for hook in model._gradient_release_hooks:
+        if hasattr(hook, "remove"):
+            hook.remove()
+    del model._gradient_release_hooks

--- a/optimi/lion.py
+++ b/optimi/lion.py
@@ -13,19 +13,18 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Iterable
-from warnings import warn
 
 import torch
 from torch import Tensor
-from torch.optim.optimizer import Optimizer, _default_to_fused_or_foreach
+from torch.optim.optimizer import _default_to_fused_or_foreach
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
-from optimi.utils import MIN_TORCH_2_1
+from optimi.optimizer import OptimiOptimizer
 
 __all__ = ["Lion", "lion"]
 
 
-class Lion(Optimizer):
+class Lion(OptimiOptimizer):
     """Lion optimizer. Evolved Sign Momentum.
 
     Args:
@@ -44,6 +43,9 @@ class Lion(Optimizer):
             parameters (default: None)
         foreach: Enables the foreach implementation. If unspecified, tries to use foreach over
             for-loop implementation since it is significantly faster (default: None)
+        gradient_release: Fuses optimizer step and zero_grad as part of the parameter's backward
+            pass. Requires model hooks created with `register_gradient_release`. Incompatible with
+            closure (default: False)
     """
 
     def __init__(
@@ -56,30 +58,12 @@ class Lion(Optimizer):
         max_lr: float | None = None,
         kahan_sum: bool | None = None,
         foreach: bool | None = None,
+        gradient_release: bool = False,
     ):
-        if not 0.0 <= lr:
-            raise ValueError(f"Invalid learning rate: {lr=}")
         if not 0.0 <= betas[0] < 1.0:
             raise ValueError(f"Invalid beta1 parameter: {betas[0]=}")
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError(f"Invalid beta2 parameter: {betas[1]=}")
-        if not 0.0 <= weight_decay:
-            raise ValueError(f"Invalid weight decay: {weight_decay=}")
-        if decouple_lr and max_lr is None:
-            max_lr = lr
-        if max_lr is not None and not 0.0 <= max_lr:
-            raise ValueError(f"Invalid maximum learning rate: {max_lr=}")
-        if decouple_lr and weight_decay >= 1e-3:
-            warn(
-                f"You are using {weight_decay=} which is potentially high for {decouple_lr=}. Unlike decoupled weight "
-                f"decay, fully decoupled weight decay does not reduce weight decay by the learning rate.",
-                category=UserWarning,
-            )
-        if not MIN_TORCH_2_1:
-            if foreach:
-                raise ValueError(f"{foreach=} requires PyTorch 2.1 or later. Set foreach=False or upgrade PyTorch.")
-            else:
-                foreach = False
 
         defaults = dict(
             lr=lr,
@@ -90,9 +74,20 @@ class Lion(Optimizer):
             max_lr=max_lr,
             kahan_sum=kahan_sum,
             foreach=foreach,
+            gradient_release=gradient_release,
             setup=False,
         )
         super().__init__(params, defaults)
+
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor):
+        if len(state) <= 1:
+            state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+
+            if (group["kahan_sum"] or group["kahan_sum"] is None) and param.dtype in [torch.float16, torch.bfloat16]:
+                state["kahan_comp"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+                group["kahan_sum"] = True
+            else:
+                state["kahan_comp"] = None
 
     def _init_group(
         self, group: dict[str, Any], params: list[Tensor], grads: list[Tensor], exp_avgs: list[Tensor], kahan_comps: list[Tensor]
@@ -105,15 +100,7 @@ class Lion(Optimizer):
             grads.append(p.grad)
             state = self.state[p]
 
-            # State initialization
-            if len(state) == 0:
-                state["exp_avg"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-
-                if (group["kahan_sum"] or group["kahan_sum"] is None) and p.dtype in [torch.float16, torch.bfloat16]:
-                    state["kahan_comp"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                    group["kahan_sum"] = True
-                else:
-                    state["kahan_comp"] = None
+            self._init_state(group, state, p)
 
             exp_avgs.append(state["exp_avg"])
             kahan_comps.append(state["kahan_comp"])
@@ -125,26 +112,51 @@ class Lion(Optimizer):
                 _, group["foreach"] = _default_to_fused_or_foreach(params, False, False)
 
     @torch.no_grad()
-    def step(self, closure: Callable | None = None):
-        """Performs a single optimization step.
+    def step(self, closure: Callable | None = None, param: Tensor | None = None):
+        """Performs a single optimization step on the whole model or individual parameter.
 
         Args:
-            closure: A closure which reevaluates the model and returns the loss
+            closure: A closure which reevaluates the model and returns the loss. Incompatible with
+                performing an optimization step on a single `param`.
+            param: An individual parameter to perform a fused optimization step during the backward
+                pass. Requires optimizer to be initialized with `gradient_release=True` and model
+                hooks created with `register_gradient_release`. Incompatible with `closure`.
         """
         loss = None
-        if closure is not None:
+        if closure is not None and param is None:
             with torch.enable_grad():
                 loss = closure()
 
-        for group in self.param_groups:
-            params, grads, exp_avgs, kahan_comps = [], [], [], []
-            self._init_group(group, params, grads, exp_avgs, kahan_comps)
+        if param is None:
+            for group in self.param_groups:
+                params, grads, exp_avgs, kahan_comps = [], [], [], []
+                self._init_group(group, params, grads, exp_avgs, kahan_comps)
+
+                lion(
+                    params=params,
+                    grads=grads,
+                    exp_avgs=exp_avgs,
+                    kahan_comps=kahan_comps,
+                    lr=group["lr"],
+                    beta1=group["beta1"],
+                    beta2=group["beta2"],
+                    weight_decay=group["weight_decay"],
+                    decouple_lr=group["decouple_lr"],
+                    max_lr=group["max_lr"],
+                    kahan_sum=group["kahan_sum"],
+                    foreach=group["foreach"],
+                    gradient_release=False,
+                )
+        else:
+            state = self.state[param]
+            group = state["group"]
+            self._init_state(group, state, param)
 
             lion(
-                params=params,
-                grads=grads,
-                exp_avgs=exp_avgs,
-                kahan_comps=kahan_comps,
+                params=param,
+                grads=param.grad,
+                exp_avgs=state["exp_avg"],
+                kahan_comps=state["kahan_comp"],
                 lr=group["lr"],
                 beta1=group["beta1"],
                 beta2=group["beta2"],
@@ -152,7 +164,8 @@ class Lion(Optimizer):
                 decouple_lr=group["decouple_lr"],
                 max_lr=group["max_lr"],
                 kahan_sum=group["kahan_sum"],
-                foreach=group["foreach"],
+                foreach=False,
+                gradient_release=True,
             )
 
         return loss
@@ -172,6 +185,7 @@ def lion(
     max_lr: float | None = None,
     kahan_sum: bool = False,
     foreach: bool = False,
+    gradient_release: bool = False,
 ):
     """Functional API to apply a Lion optimization step.
 
@@ -190,6 +204,7 @@ def lion(
         max_lr: Maximum scheduled learning rate for `decouple_lr`
         kahan_sum: Enables Kahan summation for low precision `params`
         foreach: Enables the faster foreach implementation
+        gradient_release: Fuses optimizer step as part of the parameter's backward pass
     """
     # calculate decoupled weight decay or fully decoupled weight decay
     if weight_decay != 0:
@@ -207,14 +222,16 @@ def lion(
 
     if foreach:
         func = _foreach_lion
+    elif gradient_release:
+        func = _single_param_lion
     else:
         func = _single_lion
 
     func(
-        params=params,
-        grads=grads,
-        exp_avgs=exp_avgs,
-        kahan_comps=kahan_comps,
+        params,
+        grads,
+        exp_avgs,
+        kahan_comps,
         lr=lr,
         beta1_comp=beta1_comp,
         beta2_comp=beta2_comp,
@@ -240,29 +257,54 @@ def _single_lion(
         exp_avg = exp_avgs[i]
         kahan_comp = kahan_comps[i]
 
-        # decoupled weight decay or fully decoupled weight decay
-        if weight_decay != 0:
-            param.mul_(weight_decay)
+        _single_param_lion(
+            param,
+            grad,
+            exp_avg,
+            kahan_comp,
+            lr=lr,
+            beta1_comp=beta1_comp,
+            beta2_comp=beta2_comp,
+            weight_decay=weight_decay,
+            kahan_sum=kahan_sum,
+        )
 
-        # parameter update value
-        update = exp_avg.lerp(grad, weight=beta1_comp).sign_()
 
-        # update gradient moving average
-        exp_avg.lerp_(grad, weight=beta2_comp)
+def _single_param_lion(
+    param: Tensor,
+    grad: Tensor,
+    exp_avg: Tensor | None,
+    kahan_comp: Tensor | None,
+    *,
+    lr: float,
+    beta1_comp: float,
+    beta2_comp: float,
+    weight_decay: float,
+    kahan_sum: bool = False,
+):
+    # decoupled weight decay or fully decoupled weight decay
+    if weight_decay != 0:
+        param.mul_(weight_decay)
 
-        if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
-            # Lion step
-            kahan_comp.add_(update, alpha=-lr)
+    # parameter update value
+    update = exp_avg.lerp(grad, weight=beta1_comp).sign_()
 
-            # update weights with kahan compensation using grad as temp buffer
-            grad.copy_(param.detach())
-            param.add_(kahan_comp)
+    # update gradient moving average
+    exp_avg.lerp_(grad, weight=beta2_comp)
 
-            # save error back to kahan compensation for next iteration
-            kahan_comp.add_(grad.sub_(param))
-        else:
-            # Lion step
-            param.add_(update, alpha=-lr)
+    if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
+        # Lion step
+        kahan_comp.add_(update, alpha=-lr)
+
+        # update weights with kahan compensation using grad as temp buffer
+        grad.copy_(param.detach())
+        param.add_(kahan_comp)
+
+        # save error back to kahan compensation for next iteration
+        kahan_comp.add_(grad.sub_(param))
+    else:
+        # Lion step
+        param.add_(update, alpha=-lr)
 
 
 def _foreach_lion(

--- a/optimi/optimizer.py
+++ b/optimi/optimizer.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+from warnings import warn
+
+import torch
+from torch import Tensor
+from torch.optim.optimizer import Optimizer
+
+from optimi.utils import MIN_TORCH_2_1
+
+
+class OptimiOptimizer(Optimizer):
+    """Provides common functionality for optimi optimizers."""
+
+    def __init__(self, params: Iterable[Tensor] | Iterable[dict], defaults: dict[str, Any]):
+        if not MIN_TORCH_2_1:
+            if defaults["foreach"]:
+                foreach = defaults["foreach"]
+                raise ValueError(f"{foreach=} requires PyTorch 2.1 or later. Set foreach=False or upgrade PyTorch.")
+            else:
+                defaults["foreach"] = False
+
+        if defaults["decouple_lr"] and defaults["weight_decay"] >= 1e-3:
+            weight_decay = defaults["weight_decay"]
+            decouple_lr = defaults["decouple_lr"]
+            warn(
+                f"You are using {weight_decay=} which is potentially high for {decouple_lr=}. Unlike decoupled weight "
+                f"decay, fully decoupled weight decay does not reduce weight decay by the learning rate.",
+                category=UserWarning,
+            )
+
+        super().__init__(params, defaults)
+
+        if self.defaults["gradient_release"]:
+            for group in self.param_groups:
+                for p in group["params"]:
+                    self.state[p]["group"] = group
+
+    def step(self, closure: Callable | None = None, param: Tensor | None = None):
+        """Performs a single optimization step on the whole model or individual parameter.
+
+        Args:
+            closure: A closure which reevaluates the model and returns the loss. Incompatible with
+                performing an optimization step on a single `param`.
+            param: An individual parameter to perform a fused optimization step during the backward
+                pass. Requires optimizer to be initialized with `gradient_release=True` and model
+                hooks created with `register_gradient_release`. Incompatible with `closure`.
+        """
+        raise NotImplementedError
+
+    @torch._disable_dynamo
+    def zero_grad(self, set_to_none: bool = True, param: Tensor | None = None):
+        """Resets the gradients of all optimized parameters or individual parameter.
+
+        Args:
+            set_to_none: If True, the gradients will be deallocated after the call (default: True)
+            param: Resets the gradients of the passed `param`. For use with `gradient_release=True`.
+        """
+        if param is None:
+            super().zero_grad(set_to_none=set_to_none)
+        else:
+            if param.grad is not None:
+                if set_to_none:
+                    param.grad = None
+                else:
+                    if param.grad.grad_fn is not None:
+                        param.grad.detach_()
+                    else:
+                        param.grad.requires_grad_(False)

--- a/optimi/optimizer.py
+++ b/optimi/optimizer.py
@@ -40,8 +40,11 @@ class OptimiOptimizer(Optimizer):
 
         super().__init__(params, defaults)
 
+        # if gradient_release is enabled, disable foreach step so normal optimizer step won't error
         if self.defaults["gradient_release"]:
+            self.defaults["foreach"] = False
             for group in self.param_groups:
+                group["foreach"] = False
                 for p in group["params"]:
                     self.state[p]["group"] = group
 

--- a/optimi/radam.py
+++ b/optimi/radam.py
@@ -14,19 +14,19 @@ from __future__ import annotations
 
 import math
 from typing import Any, Callable, Iterable
-from warnings import warn
 
 import torch
 from torch import Tensor
-from torch.optim.optimizer import Optimizer, _default_to_fused_or_foreach
+from torch.optim.optimizer import _default_to_fused_or_foreach
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
-from optimi.utils import MIN_TORCH_2_1, debias, debias_beta
+from optimi.optimizer import OptimiOptimizer
+from optimi.utils import debias, debias_beta
 
 __all__ = ["RAdam", "radam"]
 
 
-class RAdam(Optimizer):
+class RAdam(OptimiOptimizer):
     """Rectified Adam optimizer. Optionally with decoupled weight decay.
 
     Args:
@@ -45,6 +45,9 @@ class RAdam(Optimizer):
             parameters (default: None)
         foreach: Enables the foreach implementation. If unspecified, tries to use foreach over
             for-loop implementation since it is significantly faster (default: None)
+        gradient_release: Fuses optimizer step and zero_grad as part of the parameter's backward
+            pass. Requires model hooks created with `register_gradient_release`. Incompatible with
+            closure (default: False)
     """
 
     def __init__(
@@ -59,32 +62,14 @@ class RAdam(Optimizer):
         max_lr: float | None = None,
         kahan_sum: bool | None = None,
         foreach: bool | None = None,
+        gradient_release: bool = False,
     ):
-        if not 0.0 <= lr:
-            raise ValueError(f"Invalid learning rate: {lr=}")
         if not 0.0 <= betas[0] < 1.0:
             raise ValueError(f"Invalid beta1 parameter: {betas[0]=}")
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError(f"Invalid beta2 parameter: {betas[1]=}")
-        if not 0.0 <= weight_decay:
-            raise ValueError(f"Invalid weight decay: {weight_decay=}")
         if not 0.0 <= eps:
             raise ValueError(f"Invalid epsilon: {eps=}")
-        if decouple_lr and max_lr is None:
-            max_lr = lr
-        if max_lr is not None and not 0.0 <= max_lr:
-            raise ValueError(f"Invalid maximum learning rate: {max_lr=}")
-        if decouple_lr and weight_decay >= 1e-3:
-            warn(
-                f"You are using {weight_decay=} which is potentially high for {decouple_lr=}. Unlike decoupled weight "
-                f"decay, fully decoupled weight decay does not reduce weight decay by the learning rate.",
-                category=UserWarning,
-            )
-        if not MIN_TORCH_2_1:
-            if foreach:
-                raise ValueError(f"{foreach=} requires PyTorch 2.1 or later. Set foreach=False or upgrade PyTorch.")
-            else:
-                foreach = False
 
         defaults = dict(
             lr=lr,
@@ -97,9 +82,24 @@ class RAdam(Optimizer):
             max_lr=max_lr,
             kahan_sum=kahan_sum,
             foreach=foreach,
+            gradient_release=gradient_release,
             setup=False,
         )
         super().__init__(params, defaults)
+
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor):
+        if len(state) <= 1:
+            state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+            state["exp_avg_sq"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+
+            if (group["kahan_sum"] or group["kahan_sum"] is None) and param.dtype in [torch.float16, torch.bfloat16]:
+                state["kahan_comp"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+                group["kahan_sum"] = True
+            else:
+                state["kahan_comp"] = None
+
+            if group["gradient_release"]:
+                state["step"] = torch.tensor(0, dtype=torch.int32)
 
     def _init_group(
         self,
@@ -118,16 +118,7 @@ class RAdam(Optimizer):
             grads.append(p.grad)
             state = self.state[p]
 
-            # State initialization
-            if len(state) == 0:
-                state["exp_avg"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                state["exp_avg_sq"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-
-                if (group["kahan_sum"] or group["kahan_sum"] is None) and p.dtype in [torch.float16, torch.bfloat16]:
-                    state["kahan_comp"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                    group["kahan_sum"] = True
-                else:
-                    state["kahan_comp"] = None
+            self._init_state(group, state, p)
 
             exp_avgs.append(state["exp_avg"])
             exp_avg_sqs.append(state["exp_avg_sq"])
@@ -141,38 +132,68 @@ class RAdam(Optimizer):
                 _, group["foreach"] = _default_to_fused_or_foreach(params, False, False)
 
     @torch.no_grad()
-    def step(self, closure: Callable | None = None):
-        """Performs a single optimization step.
+    def step(self, closure: Callable | None = None, param: Tensor | None = None):
+        """Performs a single optimization step on the whole model or individual parameter.
 
         Args:
-            closure: A closure which reevaluates the model and returns the loss
+            closure: A closure which reevaluates the model and returns the loss. Incompatible with
+                performing an optimization step on a single `param`.
+            param: An individual parameter to perform a fused optimization step during the backward
+                pass. Requires optimizer to be initialized with `gradient_release=True` and model
+                hooks created with `register_gradient_release`. Incompatible with `closure`.
         """
         loss = None
-        if closure is not None:
+        if closure is not None and param is None:
             with torch.enable_grad():
                 loss = closure()
 
-        for group in self.param_groups:
-            params, grads, exp_avgs, exp_avg_sqs, kahan_comps = [], [], [], [], []
-            self._init_group(group, params, grads, exp_avgs, exp_avg_sqs, kahan_comps)
+        if param is None:
+            for group in self.param_groups:
+                params, grads, exp_avgs, exp_avg_sqs, kahan_comps = [], [], [], [], []
+                self._init_group(group, params, grads, exp_avgs, exp_avg_sqs, kahan_comps)
+
+                radam(
+                    params=params,
+                    grads=grads,
+                    exp_avgs=exp_avgs,
+                    exp_avg_sqs=exp_avg_sqs,
+                    kahan_comps=kahan_comps,
+                    lr=group["lr"],
+                    beta1=group["beta1"],
+                    beta2=group["beta2"],
+                    weight_decay=group["weight_decay"],
+                    eps=group["eps"],
+                    step=group["step"],
+                    decouple_wd=group["decouple_wd"],
+                    decouple_lr=group["decouple_lr"],
+                    max_lr=group["max_lr"],
+                    kahan_sum=group["kahan_sum"],
+                    foreach=group["foreach"],
+                    gradient_release=False,
+                )
+        else:
+            state = self.state[param]
+            group = state["group"]
+            self._init_state(group, state, param)
 
             radam(
-                params=params,
-                grads=grads,
-                exp_avgs=exp_avgs,
-                exp_avg_sqs=exp_avg_sqs,
-                kahan_comps=kahan_comps,
+                params=param,
+                grads=param.grad,
+                exp_avgs=state["exp_avg"],
+                exp_avg_sqs=state["exp_avg_sq"],
+                kahan_comps=state["kahan_comp"],
                 lr=group["lr"],
                 beta1=group["beta1"],
                 beta2=group["beta2"],
                 weight_decay=group["weight_decay"],
                 eps=group["eps"],
-                step=group["step"],
+                step=state["step"],
                 decouple_wd=group["decouple_wd"],
                 decouple_lr=group["decouple_lr"],
                 max_lr=group["max_lr"],
                 kahan_sum=group["kahan_sum"],
-                foreach=group["foreach"],
+                foreach=False,
+                gradient_release=True,
             )
 
         return loss
@@ -196,6 +217,7 @@ def radam(
     max_lr: float | None = None,
     kahan_sum: bool = False,
     foreach: bool = False,
+    gradient_release: bool = False,
 ):
     """Functional API to apply an RAdam optimization step.
 
@@ -218,6 +240,7 @@ def radam(
         max_lr: Maximum scheduled learning rate for `decouple_lr`
         kahan_sum: Enables Kahan summation for low precision parameters
         foreach: Enables the faster foreach implementation
+        gradient_release: Fuses optimizer step as part of the parameter's backward pass
     """
     # calculate debiased beta hat & complement terms
     step.add_(1)
@@ -246,15 +269,17 @@ def radam(
 
     if foreach:
         func = _foreach_radam
+    elif gradient_release:
+        func = _single_param_radam
     else:
         func = _single_radam
 
     func(
-        params=params,
-        grads=grads,
-        exp_avgs=exp_avgs,
-        exp_avg_sqs=exp_avg_sqs,
-        kahan_comps=kahan_comps,
+        params,
+        grads,
+        exp_avgs,
+        exp_avg_sqs,
+        kahan_comps,
         lr=lr,
         beta1_comp=beta1_comp,
         beta2_hat=beta2_hat,
@@ -288,36 +313,69 @@ def _single_radam(
         exp_avg_sq = exp_avg_sqs[i]
         kahan_comp = kahan_comps[i]
 
-        # decoupled weight decay, fully decoupled weight decay, or L2 weight decay
-        if weight_decay != 0:
-            if decouple_wd:
-                param.mul_(weight_decay)
-            else:
-                grad.add_(param, alpha=weight_decay)
+        _single_param_radam(
+            param=param,
+            grad=grad,
+            exp_avg=exp_avg,
+            exp_avg_sq=exp_avg_sq,
+            kahan_comp=kahan_comp,
+            lr=lr,
+            beta1_comp=beta1_comp,
+            beta2_hat=beta2_hat,
+            weight_decay=weight_decay,
+            eps=eps,
+            rect=rect,
+            decouple_wd=decouple_wd,
+            kahan_sum=kahan_sum,
+        )
 
-        # update gradient moving averages with debiased betas
-        exp_avg.lerp_(grad, weight=beta1_comp)
-        exp_avg_sq.mul_(beta2_hat).addcmul_(grad, grad, value=1 - beta2_hat)
 
-        if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
-            # RAdam step
-            if rect is not None:
-                kahan_comp.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr * rect)
-            else:
-                kahan_comp.add_(exp_avg, alpha=-lr)
-
-            # update weights with kahan compensation using grad as temp buffer
-            grad.copy_(param.detach())
-            param.add_(kahan_comp)
-
-            # save error back to kahan compensation for next iteration
-            kahan_comp.add_(grad.sub_(param))
+def _single_param_radam(
+    param: Tensor,
+    grad: Tensor,
+    exp_avg: Tensor,
+    exp_avg_sq: Tensor,
+    kahan_comp: Tensor | None,
+    *,
+    lr: float,
+    beta1_comp: float,
+    beta2_hat: float,
+    weight_decay: float,
+    eps: float,
+    rect: float | None,
+    decouple_wd: bool,
+    kahan_sum: bool = False,
+):
+    # decoupled weight decay, fully decoupled weight decay, or L2 weight decay
+    if weight_decay != 0:
+        if decouple_wd:
+            param.mul_(weight_decay)
         else:
-            # RAdam step
-            if rect is not None:
-                param.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr * rect)
-            else:
-                param.add_(exp_avg, alpha=-lr)
+            grad.add_(param, alpha=weight_decay)
+
+    # update gradient moving averages with debiased betas
+    exp_avg.lerp_(grad, weight=beta1_comp)
+    exp_avg_sq.mul_(beta2_hat).addcmul_(grad, grad, value=1 - beta2_hat)
+
+    if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
+        # RAdam step
+        if rect is not None:
+            kahan_comp.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr * rect)
+        else:
+            kahan_comp.add_(exp_avg, alpha=-lr)
+
+        # update weights with kahan compensation using grad as temp buffer
+        grad.copy_(param.detach())
+        param.add_(kahan_comp)
+
+        # save error back to kahan compensation for next iteration
+        kahan_comp.add_(grad.sub_(param))
+    else:
+        # RAdam step
+        if rect is not None:
+            param.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr * rect)
+        else:
+            param.add_(exp_avg, alpha=-lr)
 
 
 def _foreach_radam(

--- a/optimi/sgd.py
+++ b/optimi/sgd.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Iterable
-from warnings import warn
 
 import torch
 from torch import Tensor
@@ -24,7 +23,6 @@ from torch.optim.optimizer import _default_to_fused_or_foreach
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
 from optimi.optimizer import OptimiOptimizer
-from optimi.utils import MIN_TORCH_2_1
 
 __all__ = ["SGD", "sgd"]
 

--- a/optimi/sgd.py
+++ b/optimi/sgd.py
@@ -71,27 +71,8 @@ class SGD(OptimiOptimizer):
         foreach: bool | None = None,
         gradient_release: bool = False,
     ):
-        if not 0.0 <= lr:
-            raise ValueError(f"Invalid learning rate: {lr=}")
         if not 0.0 <= momentum < 1.0:
             raise ValueError(f"Invalid momentum: {momentum=}")
-        if not 0.0 <= weight_decay:
-            raise ValueError(f"Invalid weight decay: {weight_decay=}")
-        if decouple_lr and max_lr is None:
-            max_lr = lr
-        if max_lr is not None and not 0.0 <= max_lr:
-            raise ValueError(f"Invalid maximum learning rate: {max_lr=}")
-        if decouple_lr and weight_decay >= 1e-3:
-            warn(
-                f"You are using {weight_decay=} which is potentially high for {decouple_lr=}. Unlike decoupled weight "
-                f"decay, fully decoupled weight decay does not reduce weight decay by the learning rate.",
-                category=UserWarning,
-            )
-        if not MIN_TORCH_2_1:
-            if foreach:
-                raise ValueError(f"{foreach=} requires PyTorch 2.1 or later. Set foreach=False or upgrade PyTorch.")
-            else:
-                foreach = False
 
         defaults = dict(
             lr=lr,

--- a/optimi/sgd.py
+++ b/optimi/sgd.py
@@ -20,15 +20,16 @@ from warnings import warn
 
 import torch
 from torch import Tensor
-from torch.optim.optimizer import Optimizer, _default_to_fused_or_foreach
+from torch.optim.optimizer import _default_to_fused_or_foreach
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
+from optimi.optimizer import OptimiOptimizer
 from optimi.utils import MIN_TORCH_2_1
 
 __all__ = ["SGD", "sgd"]
 
 
-class SGD(Optimizer):
+class SGD(OptimiOptimizer):
     """SGD optimizer. Optionally with momentum and decoupled weight decay.
 
     Args:
@@ -50,6 +51,9 @@ class SGD(Optimizer):
             parameters (default: None)
         foreach: Enables the foreach implementation. If unspecified, tries to use foreach over
             for-loop implementation since it is significantly faster (default: None)
+        gradient_release: Fuses optimizer step and zero_grad as part of the parameter's backward
+            pass. Requires model hooks created with `register_gradient_release`. Incompatible with
+            closure (default: False)
     """
 
     def __init__(
@@ -65,6 +69,7 @@ class SGD(Optimizer):
         torch_init: bool = False,
         kahan_sum: bool | None = None,
         foreach: bool | None = None,
+        gradient_release: bool = False,
     ):
         if not 0.0 <= lr:
             raise ValueError(f"Invalid learning rate: {lr=}")
@@ -99,9 +104,23 @@ class SGD(Optimizer):
             kahan_sum=kahan_sum,
             torch_init=torch_init,
             foreach=foreach,
+            gradient_release=gradient_release,
             setup=False,
         )
         super().__init__(params, defaults)
+
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor):
+        if len(state) <= 1:
+            if group["dampening"] and group["torch_init"]:
+                state["exp_avg"] = param.grad.detach().clone()
+            else:
+                state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+
+            if (group["kahan_sum"] or group["kahan_sum"] is None) and param.dtype in [torch.float16, torch.bfloat16]:
+                state["kahan_comp"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+                group["kahan_sum"] = True
+            else:
+                state["kahan_comp"] = None
 
     def _init_group(
         self, group: dict[str, Any], params: list[Tensor], grads: list[Tensor], exp_avgs: list[Tensor], kahan_comps: list[Tensor]
@@ -114,18 +133,7 @@ class SGD(Optimizer):
             grads.append(p.grad)
             state = self.state[p]
 
-            # State initialization
-            if len(state) == 0:
-                if group["dampening"] and group["torch_init"]:
-                    state["exp_avg"] = p.grad.detach().clone()
-                else:
-                    state["exp_avg"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-
-                if (group["kahan_sum"] or group["kahan_sum"] is None) and p.dtype in [torch.float16, torch.bfloat16]:
-                    state["kahan_comp"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                    group["kahan_sum"] = True
-                else:
-                    state["kahan_comp"] = None
+            self._init_state(group, state, p)
 
             exp_avgs.append(state["exp_avg"])
             kahan_comps.append(state["kahan_comp"])
@@ -137,26 +145,52 @@ class SGD(Optimizer):
                 _, group["foreach"] = _default_to_fused_or_foreach(params, False, False)
 
     @torch.no_grad()
-    def step(self, closure: Callable | None = None):
-        """Performs a single optimization step.
+    def step(self, closure: Callable | None = None, param: Tensor | None = None):
+        """Performs a single optimization step on the whole model or individual parameter.
 
         Args:
-            closure: A closure which reevaluates the model and returns the loss
+            closure: A closure which reevaluates the model and returns the loss. Incompatible with
+                performing an optimization step on a single `param`.
+            param: An individual parameter to perform a fused optimization step during the backward
+                pass. Requires optimizer to be initialized with `gradient_release=True` and model
+                hooks created with `register_gradient_release`. Incompatible with `closure`.
         """
         loss = None
-        if closure is not None:
+        if closure is not None and param is None:
             with torch.enable_grad():
                 loss = closure()
 
-        for group in self.param_groups:
-            params, grads, exp_avgs, kahan_comps = [], [], [], []
-            self._init_group(group, params, grads, exp_avgs, kahan_comps)
+        if param is None:
+            for group in self.param_groups:
+                params, grads, exp_avgs, kahan_comps = [], [], [], []
+                self._init_group(group, params, grads, exp_avgs, kahan_comps)
+
+                sgd(
+                    params=params,
+                    grads=grads,
+                    exp_avgs=exp_avgs,
+                    kahan_comps=kahan_comps,
+                    lr=group["lr"],
+                    momentum=group["momentum"],
+                    weight_decay=group["weight_decay"],
+                    dampening=group["dampening"],
+                    decouple_wd=group["decouple_wd"],
+                    decouple_lr=group["decouple_lr"],
+                    max_lr=group["max_lr"],
+                    kahan_sum=group["kahan_sum"],
+                    foreach=group["foreach"],
+                    gradient_release=False,
+                )
+        else:
+            state = self.state[param]
+            group = state["group"]
+            self._init_state(group, state, param)
 
             sgd(
-                params=params,
-                grads=grads,
-                exp_avgs=exp_avgs,
-                kahan_comps=kahan_comps,
+                params=param,
+                grads=param.grad,
+                exp_avgs=state["exp_avg"],
+                kahan_comps=state["kahan_comp"],
                 lr=group["lr"],
                 momentum=group["momentum"],
                 weight_decay=group["weight_decay"],
@@ -165,17 +199,18 @@ class SGD(Optimizer):
                 decouple_lr=group["decouple_lr"],
                 max_lr=group["max_lr"],
                 kahan_sum=group["kahan_sum"],
-                foreach=group["foreach"],
+                foreach=False,
+                gradient_release=True,
             )
 
         return loss
 
 
 def sgd(
-    params: list[Tensor],
-    grads: list[Tensor],
-    exp_avgs: list[Tensor | None],
-    kahan_comps: list[Tensor | None] | None = None,
+    params: list[Tensor] | Tensor,
+    grads: list[Tensor] | Tensor,
+    exp_avgs: list[Tensor | None] | Tensor | None,
+    kahan_comps: list[Tensor | None] | Tensor | None = None,
     *,
     lr: float,
     momentum: float,
@@ -186,16 +221,17 @@ def sgd(
     max_lr: float | None = None,
     kahan_sum: bool = False,
     foreach: bool = False,
+    gradient_release: bool = False,
 ):
     """Functional API to apply a SGD or SGDW optimization step.
 
     See `optimi.SGD` for more details.
 
     Args:
-        params: Parameters to update
-        grads: Parameter gradients
-        exp_avgs: Momentum buffers
-        kahan_comps: Kahan summation compensations
+        params: Parameter(s) to update
+        grads: Paramete(s) gradients
+        exp_avgs: Momentum buffer(s)
+        kahan_comps: Kahan summation compensation(s)
         lr: Learning rate
         momentum: Momentum factor
         weight_decay: Weight decay coefficient
@@ -205,6 +241,7 @@ def sgd(
         max_lr: Maximum scheduled learning rate for `decouple_lr`
         kahan_sum: Enables Kahan summation for low precision `params`
         foreach: Enables the faster foreach implementation
+        gradient_release: Fuses optimizer step as part of the parameter's backward pass
     """
     # calculate decoupled weight decay or fully decoupled weight decay
     if weight_decay != 0:
@@ -218,14 +255,16 @@ def sgd(
 
     if foreach:
         func = _foreach_sgd
+    elif gradient_release:
+        func = _single_param_sgd
     else:
         func = _single_sgd
 
     func(
-        params=params,
-        grads=grads,
-        exp_avgs=exp_avgs,
-        kahan_comps=kahan_comps,
+        params,
+        grads,
+        exp_avgs,
+        kahan_comps,
         lr=lr,
         momentum=momentum,
         weight_decay=weight_decay,
@@ -253,47 +292,74 @@ def _single_sgd(
         exp_avg = exp_avgs[i]
         kahan_comp = kahan_comps[i]
 
-        # decoupled weight decay, fully decoupled weight decay, or L2 weight decay
-        if weight_decay != 0:
-            if decouple_wd:
-                param.mul_(weight_decay)
-            else:
-                grad.add_(param, alpha=weight_decay)
+        _single_param_sgd(
+            param=param,
+            grad=grad,
+            exp_avg=exp_avg,
+            kahan_comp=kahan_comp,
+            lr=lr,
+            momentum=momentum,
+            weight_decay=weight_decay,
+            dampening=dampening,
+            decouple_wd=decouple_wd,
+            kahan_sum=kahan_sum,
+        )
 
-        if momentum != 0:
-            # SGD Momentum
-            if dampening:
-                exp_avg.lerp_(grad, weight=1 - momentum)
-            else:
-                exp_avg.mul_(momentum).add_(grad)
 
-            if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
-                # SGD with Momentum step
-                kahan_comp.add_(exp_avg, alpha=-lr)
-
-                # update weights with kahan compensation using grad as temp buffer
-                grad.copy_(param.detach())
-                param.add_(kahan_comp)
-
-                # save error back to kahan compensation for next iteration
-                kahan_comp.add_(grad.sub_(param))
-            else:
-                # SGD with Momentum step
-                param.add_(exp_avg, alpha=-lr)
+def _single_param_sgd(
+    param: Tensor,
+    grad: Tensor,
+    exp_avg: Tensor | None,
+    kahan_comp: Tensor | None,
+    *,
+    lr: float,
+    momentum: float,
+    weight_decay: float,
+    dampening: bool,
+    decouple_wd: bool,
+    kahan_sum: bool = False,
+):
+    # decoupled weight decay, fully decoupled weight decay, or L2 weight decay
+    if weight_decay != 0:
+        if decouple_wd:
+            param.mul_(weight_decay)
         else:
-            if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
-                # SGD step
-                kahan_comp.add_(grad, alpha=-lr)
+            grad.add_(param, alpha=weight_decay)
 
-                # update weights with kahan compensation using grad as temp buffer
-                grad.copy_(param.detach())
-                param.add_(kahan_comp)
+    if momentum != 0:
+        # SGD Momentum
+        if dampening:
+            exp_avg.lerp_(grad, weight=1 - momentum)
+        else:
+            exp_avg.mul_(momentum).add_(grad)
 
-                # save error back to kahan compensation for next iteration
-                kahan_comp.add_(grad.sub_(param))
-            else:
-                # SGD step
-                param.add_(grad, alpha=-lr)
+        if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
+            # SGD with Momentum step
+            kahan_comp.add_(exp_avg, alpha=-lr)
+
+            # update weights with kahan compensation using grad as temp buffer
+            grad.copy_(param.detach())
+            param.add_(kahan_comp)
+
+            # save error back to kahan compensation for next iteration
+            kahan_comp.add_(grad.sub_(param))
+        else:
+            # SGD with Momentum step
+            param.add_(exp_avg, alpha=-lr)
+    else:
+        if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
+            # SGD step
+            kahan_comp.add_(grad, alpha=-lr)
+
+            # update weights with kahan compensation using grad as temp buffer
+            grad.copy_(param.detach())
+            param.add_(kahan_comp)
+
+            # save error back to kahan compensation for next iteration
+            kahan_comp.add_(grad.sub_(param))
+        else:
+            # SGD step
+            param.add_(grad, alpha=-lr)
 
 
 def _foreach_sgd(

--- a/optimi/stableadamw.py
+++ b/optimi/stableadamw.py
@@ -13,7 +13,6 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Iterable
-from warnings import warn
 
 import torch
 from torch import Tensor

--- a/optimi/stableadamw.py
+++ b/optimi/stableadamw.py
@@ -84,7 +84,7 @@ class StableAdamW(OptimiOptimizer):
         )
         super().__init__(params, defaults)
 
-    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor, gradient_release: bool = False):
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor):
         if len(state) <= 1:
             state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
             state["exp_avg_sq"] = torch.zeros_like(param, memory_format=torch.preserve_format)
@@ -96,7 +96,7 @@ class StableAdamW(OptimiOptimizer):
             else:
                 state["kahan_comp"] = None
 
-            if gradient_release:
+            if group["gradient_release"]:
                 state["step"] = torch.tensor(0, dtype=torch.int32)
 
     def _init_group(
@@ -174,7 +174,7 @@ class StableAdamW(OptimiOptimizer):
         else:
             state = self.state[param]
             group = state["group"]
-            self._init_state(group, state, param, True)
+            self._init_state(group, state, param)
 
             stableadamw(
                 params=param,

--- a/optimi/stableadamw.py
+++ b/optimi/stableadamw.py
@@ -17,15 +17,16 @@ from warnings import warn
 
 import torch
 from torch import Tensor
-from torch.optim.optimizer import Optimizer, _default_to_fused_or_foreach
+from torch.optim.optimizer import _default_to_fused_or_foreach
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
-from optimi.utils import MIN_TORCH_2_1, debias_beta
+from optimi.optimizer import OptimiOptimizer
+from optimi.utils import debias_beta
 
 __all__ = ["StableAdamW", "stableadamw"]
 
 
-class StableAdamW(Optimizer):
+class StableAdamW(OptimiOptimizer):
     """StableAdamW optimizer. An AdamW-Adafactor hybrid with learning rate update clipping.
 
     Args:
@@ -44,6 +45,9 @@ class StableAdamW(Optimizer):
             parameters (default: None)
         foreach: Enables the foreach implementation. If unspecified, tries to use foreach over
             for-loop implementation since it is significantly faster (default: None)
+        gradient_release: Fuses optimizer step and zero_grad as part of the parameter's backward
+            pass. Requires model hooks created with `register_gradient_release`. Incompatible with
+            closure (default: False)
     """
 
     def __init__(
@@ -57,32 +61,14 @@ class StableAdamW(Optimizer):
         max_lr: float | None = None,
         kahan_sum: bool | None = None,
         foreach: bool | None = None,
+        gradient_release: bool = False,
     ):
-        if not 0.0 <= lr:
-            raise ValueError(f"Invalid learning rate: {lr=}")
         if not 0.0 <= betas[0] < 1.0:
             raise ValueError(f"Invalid beta1 parameter: {betas[0]=}")
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError(f"Invalid beta2 parameter: {betas[1]=}")
-        if not 0.0 <= weight_decay:
-            raise ValueError(f"Invalid weight decay: {weight_decay=}")
         if not 0.0 <= eps:
             raise ValueError(f"Invalid epsilon: {eps=}")
-        if decouple_lr and max_lr is None:
-            max_lr = lr
-        if max_lr is not None and not 0.0 <= max_lr:
-            raise ValueError(f"Invalid maximum learning rate: {max_lr=}")
-        if decouple_lr and weight_decay >= 1e-3:
-            warn(
-                f"You are using {weight_decay=} which is potentially high for {decouple_lr=}. Unlike decoupled weight "
-                f"decay, fully decoupled weight decay does not reduce weight decay by the learning rate.",
-                category=UserWarning,
-            )
-        if not MIN_TORCH_2_1:
-            if foreach:
-                raise ValueError(f"{foreach=} requires PyTorch 2.1 or later. Set foreach=False or upgrade PyTorch.")
-            else:
-                foreach = False
 
         defaults = dict(
             lr=lr,
@@ -94,9 +80,25 @@ class StableAdamW(Optimizer):
             max_lr=max_lr,
             kahan_sum=kahan_sum,
             foreach=foreach,
+            gradient_release=gradient_release,
             setup=False,
         )
         super().__init__(params, defaults)
+
+    def _init_state(self, group: dict[str, Any], state: dict[Tensor, Any], param: Tensor, gradient_release: bool = False):
+        if len(state) <= 1:
+            state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+            state["exp_avg_sq"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+            state["eps_sq"] = torch.tensor(group["eps"] ** 2, dtype=param.dtype, device=param.device)
+
+            if (group["kahan_sum"] or group["kahan_sum"] is None) and param.dtype in [torch.float16, torch.bfloat16]:
+                state["kahan_comp"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+                group["kahan_sum"] = True
+            else:
+                state["kahan_comp"] = None
+
+            if gradient_release:
+                state["step"] = torch.tensor(0, dtype=torch.int32)
 
     def _init_group(
         self,
@@ -116,17 +118,7 @@ class StableAdamW(Optimizer):
             grads.append(p.grad)
             state = self.state[p]
 
-            # State initialization
-            if len(state) == 0:
-                state["exp_avg"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                state["exp_avg_sq"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                state["eps_sq"] = torch.tensor(group["eps"] ** 2, dtype=p.dtype, device=p.device)
-
-                if (group["kahan_sum"] or group["kahan_sum"] is None) and p.dtype in [torch.float16, torch.bfloat16]:
-                    state["kahan_comp"] = torch.zeros_like(p, memory_format=torch.preserve_format)
-                    group["kahan_sum"] = True
-                else:
-                    state["kahan_comp"] = None
+            self._init_state(group, state, p)
 
             exp_avgs.append(state["exp_avg"])
             exp_avg_sqs.append(state["exp_avg_sq"])
@@ -141,38 +133,68 @@ class StableAdamW(Optimizer):
                 _, group["foreach"] = _default_to_fused_or_foreach(params, False, False)
 
     @torch.no_grad()
-    def step(self, closure: Callable | None = None):
-        """Performs a single optimization step.
+    def step(self, closure: Callable | None = None, param: Tensor | None = None):
+        """Performs a single optimization step on the whole model or individual parameter.
 
         Args:
-            closure: A closure which reevaluates the model and returns the loss
+            closure: A closure which reevaluates the model and returns the loss. Incompatible with
+                performing an optimization step on a single `param`.
+            param: An individual parameter to perform a fused optimization step during the backward
+                pass. Requires optimizer to be initialized with `gradient_release=True` and model
+                hooks created with `register_gradient_release`. Incompatible with `closure`.
         """
         loss = None
-        if closure is not None:
+        if closure is not None and param is None:
             with torch.enable_grad():
                 loss = closure()
 
-        for group in self.param_groups:
-            params, grads, exp_avgs, exp_avg_sqs, eps_sqs, kahan_comps = [], [], [], [], [], []
-            self._init_group(group, params, grads, exp_avgs, exp_avg_sqs, eps_sqs, kahan_comps)
+        if param is None:
+            for group in self.param_groups:
+                params, grads, exp_avgs, exp_avg_sqs, eps_sqs, kahan_comps = [], [], [], [], [], []
+                self._init_group(group, params, grads, exp_avgs, exp_avg_sqs, eps_sqs, kahan_comps)
+
+                stableadamw(
+                    params=params,
+                    grads=grads,
+                    exp_avgs=exp_avgs,
+                    exp_avg_sqs=exp_avg_sqs,
+                    eps_sqs=eps_sqs,
+                    kahan_comps=kahan_comps,
+                    lr=group["lr"],
+                    beta1=group["beta1"],
+                    beta2=group["beta2"],
+                    weight_decay=group["weight_decay"],
+                    eps=group["eps"],
+                    step=group["step"],
+                    decouple_lr=group["decouple_lr"],
+                    max_lr=group["max_lr"],
+                    kahan_sum=group["kahan_sum"],
+                    foreach=group["foreach"],
+                    gradient_release=False,
+                )
+        else:
+            state = self.state[param]
+            group = state["group"]
+            self._init_state(group, state, param, True)
 
             stableadamw(
-                params=params,
-                grads=grads,
-                exp_avgs=exp_avgs,
-                exp_avg_sqs=exp_avg_sqs,
-                eps_sqs=eps_sqs,
-                kahan_comps=kahan_comps,
+                params=param,
+                grads=param.grad,
+                exp_avgs=state["exp_avg"],
+                exp_avg_sqs=state["exp_avg_sq"],
+                eps_sqs=state["eps_sq"],
+                kahan_comps=state["kahan_comp"],
                 lr=group["lr"],
                 beta1=group["beta1"],
                 beta2=group["beta2"],
                 weight_decay=group["weight_decay"],
                 eps=group["eps"],
-                step=group["step"],
+                step=state["step"],
                 decouple_lr=group["decouple_lr"],
                 max_lr=group["max_lr"],
                 kahan_sum=group["kahan_sum"],
                 foreach=group["foreach"],
+                gradient_release=True,
             )
 
         return loss
@@ -196,6 +218,7 @@ def stableadamw(
     max_lr: float | None = None,
     kahan_sum: bool = False,
     foreach: bool = False,
+    gradient_release: bool = False,
 ):
     """Functional API to apply a StableAdamW optimization step.
 
@@ -218,6 +241,7 @@ def stableadamw(
         max_lr: Maximum scheduled learning rate for `decouple_lr`
         kahan_sum: Enables Kahan summation for low precision parameters
         foreach: Enables the faster foreach implementation
+        gradient_release: Fuses optimizer step as part of the parameter's backward pass
     """
     # calculate debiased beta hat & complement terms
     step.add_(1)
@@ -229,16 +253,18 @@ def stableadamw(
 
     if foreach:
         func = _foreach_stableadamw
+    elif gradient_release:
+        func = _single_param_stableadamw
     else:
         func = _single_stableadamw
 
     func(
-        params=params,
-        grads=grads,
-        exp_avgs=exp_avgs,
-        exp_avg_sqs=exp_avg_sqs,
-        eps_sqs=eps_sqs,
-        kahan_comps=kahan_comps,
+        params,
+        grads,
+        exp_avgs,
+        exp_avg_sqs,
+        eps_sqs,
+        kahan_comps,
         lr=lr,
         beta1_comp=beta1_comp,
         beta2_hat=beta2_hat,
@@ -274,37 +300,72 @@ def _single_stableadamw(
         kahan_comp = kahan_comps[i]
         eps_sq = eps_sqs[i]
 
-        # update gradient moving averages with debiased betas
-        exp_avg.lerp_(grad, weight=beta1_comp)
-        exp_avg_sq.mul_(beta2_hat).addcmul_(grad, grad, value=1 - beta2_hat)
+        _single_param_stableadamw(
+            param=param,
+            grad=grad,
+            exp_avg=exp_avg,
+            exp_avg_sq=exp_avg_sq,
+            eps_sq=eps_sq,
+            kahan_comp=kahan_comp,
+            lr=lr,
+            beta1_comp=beta1_comp,
+            beta2_hat=beta2_hat,
+            weight_decay=weight_decay,
+            eps=eps,
+            decouple_lr=decouple_lr,
+            max_lr=max_lr,
+            kahan_sum=kahan_sum,
+        )
 
-        # compute per tensor RMS stabilization term
-        rms = grad.pow(2).div_(exp_avg_sq.maximum(eps_sq)).mean().sqrt()
 
-        # calculate RMS stabilized learning rate
-        lr = lr / max(1, rms.item())
+def _single_param_stableadamw(
+    param: Tensor,
+    grad: Tensor,
+    exp_avg: Tensor,
+    exp_avg_sq: Tensor,
+    eps_sq: Tensor,
+    kahan_comp: Tensor | None,
+    *,
+    lr: float,
+    beta1_comp: float,
+    beta2_hat: float,
+    weight_decay: float,
+    eps: float,
+    decouple_lr: bool,
+    max_lr: float | None = None,
+    kahan_sum: bool = False,
+):
+    # update gradient moving averages with debiased betas
+    exp_avg.lerp_(grad, weight=beta1_comp)
+    exp_avg_sq.mul_(beta2_hat).addcmul_(grad, grad, value=1 - beta2_hat)
 
-        # decoupled weight decay or fully decoupled weight decay
-        if weight_decay != 0:
-            if decouple_lr:
-                weight_decay = 1 - (lr / max_lr) * weight_decay
-            else:
-                weight_decay = 1 - lr * weight_decay
-            param.mul_(weight_decay)
+    # compute per tensor RMS stabilization term
+    rms = grad.pow(2).div_(exp_avg_sq.maximum(eps_sq)).mean().sqrt()
 
-        if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
-            # Adam step
-            kahan_comp.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
+    # calculate RMS stabilized learning rate
+    lr = lr / max(1, rms.item())
 
-            # update weights with kahan compensation using grad as temp buffer
-            grad.copy_(param.detach())
-            param.add_(kahan_comp)
-
-            # save error back to kahan compensation for next iteration
-            kahan_comp.add_(grad.sub_(param))
+    # decoupled weight decay or fully decoupled weight decay
+    if weight_decay != 0:
+        if decouple_lr:
+            weight_decay = 1 - (lr / max_lr) * weight_decay
         else:
-            # Adam step
-            param.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
+            weight_decay = 1 - lr * weight_decay
+        param.mul_(weight_decay)
+
+    if kahan_sum and param.dtype in [torch.float16, torch.bfloat16]:
+        # Adam step
+        kahan_comp.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
+
+        # update weights with kahan compensation using grad as temp buffer
+        grad.copy_(param.detach())
+        param.add_(kahan_comp)
+
+        # save error back to kahan compensation for next iteration
+        kahan_comp.add_(grad.sub_(param))
+    else:
+        # Adam step
+        param.addcdiv_(exp_avg, exp_avg_sq.sqrt().add_(eps), value=-lr)
 
 
 def _foreach_stableadamw(

--- a/optimi/stableadamw.py
+++ b/optimi/stableadamw.py
@@ -192,7 +192,7 @@ class StableAdamW(OptimiOptimizer):
                 decouple_lr=group["decouple_lr"],
                 max_lr=group["max_lr"],
                 kahan_sum=group["kahan_sum"],
-                foreach=group["foreach"],
+                foreach=False,
                 gradient_release=True,
             )
 

--- a/tests/adam_test.py
+++ b/tests/adam_test.py
@@ -6,8 +6,9 @@ import torch
 import optimi
 from tests import reference
 
-from tests.optimizer_test import buffer, run_optimizer, cpu_dim1, cpu_dim2, cpu_gtype, cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype
-
+from tests.optimizer_test import (buffer, run_optimizer, gradient_release, cpu_dim1, cpu_dim2, cpu_gtype,
+                                  cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype, gr_dim1,
+                                  gr_dim2, gr_dtype, gr_ftype)
 
 
 optimizers = {}
@@ -48,3 +49,13 @@ cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cu
 @pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
 def test_optimizer_cuda(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
     run_optimizer(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'), buffer, iterations=80)
+
+
+cuda_values = list(product(gr_dim1, gr_dim2, gr_dtype, optimizer_names, gr_ftype))
+cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cuda_values]
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
+def test_gradient_release(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
+    gradient_release(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'),
+                     iterations=80, framework_opt_step=torch.rand(1).item() > 0.5)

--- a/tests/adan_test.py
+++ b/tests/adan_test.py
@@ -6,7 +6,9 @@ import torch
 import optimi
 from tests import reference
 
-from tests.optimizer_test import buffer, run_optimizer, cpu_dim1, cpu_dim2, cpu_gtype, cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype
+from tests.optimizer_test import (buffer, run_optimizer, gradient_release, cpu_dim1, cpu_dim2, cpu_gtype,
+                                  cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype, gr_dim1,
+                                  gr_dim2, gr_dtype, gr_ftype)
 
 
 
@@ -46,3 +48,13 @@ cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cu
 def test_optimizer_cuda(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
     # Adan bfloat16 updates are noisier, so GPU currently doesn't use longer test iterations
     run_optimizer(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'), buffer, iterations=20 if gtype==torch.bfloat16 else 80)
+
+
+cuda_values = list(product(gr_dim1, gr_dim2, gr_dtype, optimizer_names, gr_ftype))
+cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cuda_values]
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
+def test_gradient_release(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
+    gradient_release(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'),
+                     iterations=80, framework_opt_step=torch.rand(1).item() > 0.5)

--- a/tests/lion_test.py
+++ b/tests/lion_test.py
@@ -6,7 +6,9 @@ import torch
 import optimi
 from tests import reference
 
-from tests.optimizer_test import buffer, run_optimizer, cpu_dim1, cpu_dim2, cpu_gtype, cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype
+from tests.optimizer_test import (buffer, run_optimizer, gradient_release, cpu_dim1, cpu_dim2, cpu_gtype,
+                                  cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype, gr_dim1,
+                                  gr_dim2, gr_dtype, gr_ftype)
 
 
 
@@ -42,3 +44,14 @@ cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cu
 @pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
 def test_optimizer_cuda(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
     run_optimizer(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'), buffer, iterations=80)
+
+
+
+cuda_values = list(product(gr_dim1, gr_dim2, gr_dtype, optimizer_names, gr_ftype))
+cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cuda_values]
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
+def test_gradient_release(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
+    gradient_release(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'),
+                     iterations=80, framework_opt_step=torch.rand(1).item() > 0.5)

--- a/tests/optimizer_test.py
+++ b/tests/optimizer_test.py
@@ -144,14 +144,11 @@ def gradient_release(optimizers:dict, dim1:int, dim2:int, dtype:torch.dtype, opt
 
 
     # PyTorch Method: taken from https://pytorch.org/tutorials/intermediate/optimizer_step_in_backward_tutorial.html
+    torch_optimizers = {p: load_optimizer([p], optimizers, optim_name, 0, ftype) for p in m2.parameters()}
+
     pytorch_hooks = []
     for p in m2.parameters():
         pytorch_hooks.append(p.register_post_accumulate_grad_hook(optimizer_hook))
-
-    torch_optimizers = {p: load_optimizer([p], optimizers, optim_name, 0, ftype) for p in m2.parameters()}
-
-    for p in m2.parameters():
-        optimizer_hook(p)
 
 
     # Optimim Method

--- a/tests/optimizer_test.py
+++ b/tests/optimizer_test.py
@@ -127,6 +127,9 @@ def gradient_release(optimizers:dict, dim1:int, dim2:int, dtype:torch.dtype, opt
         torch_optimizers[parameter].step()
         torch_optimizers[parameter].zero_grad()
 
+    # Since Lion & Adan can have noisy updates, allow up to 10 errors
+    max_error_count = 10
+
     if dtype == torch.float32:
         atol, rtol = 1e-6, 1e-5
     elif dtype == torch.bfloat16:
@@ -189,10 +192,10 @@ def gradient_release(optimizers:dict, dim1:int, dim2:int, dtype:torch.dtype, opt
             optimi_optimizer.step()
             optimi_optimizer.zero_grad()
 
-        assert_most_approx_close(m1.fc1.weight, m2.fc1.weight, rtol=rtol, atol=atol)
-        assert_most_approx_close(m1.fc2.weight, m2.fc2.weight, rtol=rtol, atol=atol)
-        assert_most_approx_close(m1.fc1.weight, m3.fc1.weight, rtol=rtol, atol=atol)
-        assert_most_approx_close(m1.fc2.weight, m3.fc2.weight, rtol=rtol, atol=atol)
+        assert_most_approx_close(m1.fc1.weight, m2.fc1.weight, rtol=rtol, atol=atol, max_error_count=max_error_count)
+        assert_most_approx_close(m1.fc2.weight, m2.fc2.weight, rtol=rtol, atol=atol, max_error_count=max_error_count)
+        assert_most_approx_close(m1.fc1.weight, m3.fc1.weight, rtol=rtol, atol=atol, max_error_count=max_error_count)
+        assert_most_approx_close(m1.fc2.weight, m3.fc2.weight, rtol=rtol, atol=atol, max_error_count=max_error_count)
 
     for h in pytorch_hooks:
         h.remove()

--- a/tests/optimizer_test.py
+++ b/tests/optimizer_test.py
@@ -6,6 +6,22 @@ import io
 
 import torch
 
+from optimi import prepare_for_gradient_release, remove_gradient_release
+
+
+class MLP(torch.nn.Module):
+    def __init__(self, input_size, hidden_size, device, dtype):
+        super().__init__()
+        self.fc1 = torch.nn.Linear(input_size, hidden_size, bias=False, device=device, dtype=dtype)
+        self.act = torch.nn.Mish()
+        self.fc2 = torch.nn.Linear(hidden_size, 1, bias=False, device=device, dtype=dtype)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.fc2(x)
+        return x
+
 
 def assert_most_approx_close(a, b, rtol=1e-3, atol=1e-3, max_error_count=0, max_error_rate=None):
     idx = torch.isclose(a, b, rtol=rtol, atol=atol)
@@ -105,6 +121,86 @@ def run_optimizer(optimizers:dict, dim1:int, dim2:int, gtype:torch.dtype, optim_
                 assert_most_approx_close(p1, p2.float(), atol, rtol, max_error_count=max_error_count)
 
 
+def gradient_release(optimizers:dict, dim1:int, dim2:int, dtype:torch.dtype, optim_name:str,
+                    ftype:str, device:torch.device, iterations:int=20, framework_opt_step:bool=False):
+    def optimizer_hook(parameter) -> None:
+        torch_optimizers[parameter].step()
+        torch_optimizers[parameter].zero_grad()
+
+    if dtype == torch.float32:
+        atol, rtol = 1e-6, 1e-5
+    elif dtype == torch.bfloat16:
+        atol, rtol = 1e-3, 1e-2
+    elif dtype == torch.float16:
+        atol, rtol = 1e-4, 1e-3
+
+    m1 = MLP(dim1, dim2, device=device, dtype=dtype)
+    m2 = MLP(dim1, dim2, device=device, dtype=dtype)
+    m3 = MLP(dim1, dim2, device=device, dtype=dtype)
+    m2.load_state_dict(m1.state_dict())
+    m3.load_state_dict(m1.state_dict())
+
+    regular_optimizer = load_optimizer(m1.parameters(), optimizers, optim_name, 0, ftype)
+
+
+    # PyTorch Method: taken from https://pytorch.org/tutorials/intermediate/optimizer_step_in_backward_tutorial.html
+    pytorch_hooks = []
+    for p in m2.parameters():
+        pytorch_hooks.append(p.register_post_accumulate_grad_hook(optimizer_hook))
+
+    torch_optimizers = {p: load_optimizer([p], optimizers, optim_name, 0, ftype) for p in m2.parameters()}
+
+    for p in m2.parameters():
+        optimizer_hook(p)
+
+
+    # Optimim Method
+    # add the gradient release flag to the optimizer kwargs
+    optimizers[optim_name][1]['kwargs']['gradient_release'] = True
+    optimi_optimizer = load_optimizer(m3.parameters(), optimizers, optim_name, 1, ftype)
+
+    prepare_for_gradient_release(m3, optimi_optimizer)
+
+
+    # Training loop
+    for i in range(iterations):
+        input1 = torch.randn(1, dim1, device=device, dtype=dtype)
+        input2 = input1.clone()
+        input3 = input1.clone()
+        target1 = torch.randn(1, 1, device=device, dtype=dtype)
+        target2 = target1.clone()
+        target3 = target1.clone()
+
+        output1 = m1(input1)
+        output2 = m2(input2)
+        output3 = m3(input3)
+
+        loss1 = torch.nn.functional.mse_loss(output1, target1)
+        loss2 = torch.nn.functional.mse_loss(output2, target2)
+        loss3 = torch.nn.functional.mse_loss(output3, target3)
+
+        loss1.backward()
+        loss2.backward()
+        loss3.backward()
+
+        regular_optimizer.step()
+        regular_optimizer.zero_grad()
+
+        # simulates using an optimi gradient release optimizer in a framework
+        # where the optimizer step and zero_grad cannot be disabled.
+        if framework_opt_step:
+            optimi_optimizer.step()
+            optimi_optimizer.zero_grad()
+
+        assert_most_approx_close(m1.fc1.weight, m2.fc1.weight, rtol=rtol, atol=atol)
+        assert_most_approx_close(m1.fc2.weight, m2.fc2.weight, rtol=rtol, atol=atol)
+        assert_most_approx_close(m1.fc1.weight, m3.fc1.weight, rtol=rtol, atol=atol)
+        assert_most_approx_close(m1.fc2.weight, m3.fc2.weight, rtol=rtol, atol=atol)
+
+    for h in pytorch_hooks:
+        h.remove()
+    remove_gradient_release(m3)
+
 
 buffer = io.BytesIO()
 
@@ -119,3 +215,8 @@ cuda_dim1 = [1024]
 cuda_dim2 = [64, 1024, 4096, 1]
 cuda_gtype = [torch.float32, torch.bfloat16]
 cuda_ftype = ['', '_foreach']
+
+gr_dim1 = [128]
+gr_dim2 = [256, 1024]
+gr_dtype = [torch.float32]
+gr_ftype = ['']

--- a/tests/radam_test.py
+++ b/tests/radam_test.py
@@ -4,23 +4,29 @@ import pytest
 import torch
 
 import optimi
-from tests import reference
+from packaging.version import parse
 
-from tests.optimizer_test import buffer, run_optimizer, cpu_dim1, cpu_dim2, cpu_gtype, cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype
+from tests.optimizer_test import (buffer, run_optimizer, gradient_release, cpu_dim1, cpu_dim2, cpu_gtype,
+                                  cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype, gr_dim1,
+                                  gr_dim2, gr_dtype, gr_ftype)
 
-
+# PyTorch's RAdam adds epsilon before debiasing V while Optimi debases before.
+# RAdam tests with a smaller epsilon then other optimizers to prevent numerical divergances.
 
 optimizers = {}
 
-optimizers["radam"] = ({'optim':torch.optim.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=0)},
-                       {'optim':optimi.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=0)})
+optimizers["radam"] = ({'optim':torch.optim.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=0)},
+                       {'optim':optimi.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=0)})
 
-optimizers["radam_l2"] = ({'optim':torch.optim.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=1e-2)},
-                          {'optim':optimi.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=1e-2, decouple_wd=False)})
+optimizers["radam_l2"] = ({'optim':torch.optim.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=1e-2)},
+                          {'optim':optimi.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=1e-2, decouple_wd=False)})
 
-# TODO: Enable after PyTorch 2.2 is released
-# optimizers["radamw"] = ({'optim':torch.optim.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=1e-2, decoupled_weight_decay=True)},
-#                         {'optim':optimi.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=1e-2, decouple_wd=True)})
+if parse(torch.__version__) >= parse("2.2"):
+    optimizers["radamw"] = ({'optim':torch.optim.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=1e-2, decoupled_weight_decay=True)},
+                            {'optim':optimi.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=1e-2, decouple_wd=True)})
+
+    optimizers["radam_dlr"] = ({'optim':torch.optim.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=1e-2, decoupled_weight_decay=True)},
+                               {'optim':optimi.RAdam, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=1e-5, decouple_lr=True)})
 
 optimizer_names = [key for key in optimizers.keys()]
 
@@ -43,3 +49,14 @@ cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cu
 @pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
 def test_optimizer_cuda(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
     run_optimizer(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'), buffer, iterations=80)
+
+
+
+cuda_values = list(product(gr_dim1, gr_dim2, gr_dtype, optimizer_names, gr_ftype))
+cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cuda_values]
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
+def test_gradient_release(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
+    gradient_release(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'),
+                     iterations=80, framework_opt_step=torch.rand(1).item() > 0.5)

--- a/tests/ranger_test.py
+++ b/tests/ranger_test.py
@@ -6,16 +6,19 @@ import torch
 import optimi
 from tests import reference
 
-from tests.optimizer_test import buffer, run_optimizer, cpu_dim1, cpu_dim2, cpu_gtype, cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype
+from tests.optimizer_test import (buffer, run_optimizer, gradient_release, cpu_dim1, cpu_dim2, cpu_gtype,
+                                  cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype, gr_dim1,
+                                  gr_dim2, gr_dtype, gr_ftype)
 
-
+# The reference Ranger adds epsilon before debiasing V while Optimi debases before.
+# Ranger tests with a smaller epsilon then other optimizers to prevent numerical divergances.
 
 optimizers = {}
 
-optimizers["ranger"] = ({'optim':reference.Ranger, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=0)},
-                        {'optim':optimi.Ranger, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-6, weight_decay=0)})
+optimizers["ranger"] = ({'optim':reference.Ranger, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=0)},
+                        {'optim':optimi.Ranger, 'kwargs':dict(lr=1e-3, betas=(0.9, 0.99), eps=1e-8, weight_decay=0)})
 
-# reference doesn't perform the normal weight decay step, so no test
+# reference doesn't perform the normal weight decay step, so no wd tests
 
 optimizer_names = [key for key in optimizers.keys()]
 
@@ -39,3 +42,15 @@ cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cu
 def test_optimizer_cuda(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
     # test ranger longer due to the lookahead step
     run_optimizer(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'), buffer, iterations=160)
+
+
+
+cuda_values = list(product(gr_dim1, gr_dim2, gr_dtype, optimizer_names, gr_ftype))
+cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cuda_values]
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
+def test_gradient_release(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
+    # test ranger longer due to the lookahead step
+    gradient_release(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'),
+                     iterations=160, framework_opt_step=torch.rand(1).item() > 0.5)

--- a/tests/sgd_test.py
+++ b/tests/sgd_test.py
@@ -6,7 +6,9 @@ import torch
 import optimi
 from tests import reference
 
-from tests.optimizer_test import buffer, run_optimizer, cpu_dim1, cpu_dim2, cpu_gtype, cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype
+from tests.optimizer_test import (buffer, run_optimizer, gradient_release, cpu_dim1, cpu_dim2, cpu_gtype,
+                                  cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype, gr_dim1,
+                                  gr_dim2, gr_dtype, gr_ftype)
 
 
 
@@ -48,3 +50,14 @@ cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cu
 @pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
 def test_optimizer_cuda(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
     run_optimizer(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'), buffer, iterations=80)
+
+
+
+cuda_values = list(product(gr_dim1, gr_dim2, gr_dtype, optimizer_names, gr_ftype))
+cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cuda_values]
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
+def test_gradient_release(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
+    gradient_release(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'),
+                     iterations=80, framework_opt_step=torch.rand(1).item() > 0.5)

--- a/tests/stableadam_test.py
+++ b/tests/stableadam_test.py
@@ -6,7 +6,9 @@ import torch
 import optimi
 from tests import reference
 
-from tests.optimizer_test import buffer, run_optimizer, cpu_dim1, cpu_dim2, cpu_gtype, cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype
+from tests.optimizer_test import (buffer, run_optimizer, gradient_release, cpu_dim1, cpu_dim2, cpu_gtype,
+                                  cpu_ftype, cuda_dim1, cuda_dim2, cuda_gtype, cuda_ftype, gr_dim1,
+                                  gr_dim2, gr_dtype, gr_ftype)
 
 
 
@@ -42,3 +44,13 @@ cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cu
 @pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
 def test_optimizer_cuda(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
     run_optimizer(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'), buffer, iterations=80)
+
+
+cuda_values = list(product(gr_dim1, gr_dim2, gr_dtype, optimizer_names, gr_ftype))
+cuda_names = ["dim1_{}_dim2_{}_gtype_{}_optim_{}{}".format(*vals) for vals in cuda_values]
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("dim1, dim2, gtype, optim_name, ftype", cuda_values, ids=cuda_names)
+def test_gradient_release(dim1:int, dim2:int, gtype:torch.dtype, optim_name:str, ftype:str):
+    gradient_release(optimizers, dim1, dim2, gtype, optim_name, ftype, torch.device('cuda'),
+                     iterations=80, framework_opt_step=torch.rand(1).item() > 0.5)


### PR DESCRIPTION
This PR adds support for gradient release to all optimi optimizers.

Gradient release reduces training memory by limiting gradients to one layer at any given time.

During the backward pass, each model layer calculates its gradients, performs the optimizer step, and clears the gradients before proceeding to the backward pass for the next layer. This fused backward and optimizer step can reduce non-activation memory usage by ~25 percent for an Adam optimizer.

Using optimi’s gradient release requires two steps: initializing the optimizer with `gradient_release=True` and calling `prepare_for_gradient_release` on both the model and optimizer.